### PR TITLE
Added support for contextual logging

### DIFF
--- a/src/Akka.Logger.Serilog/Akka.Logger.Serilog.csproj
+++ b/src/Akka.Logger.Serilog/Akka.Logger.Serilog.csproj
@@ -44,8 +44,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
@@ -56,12 +56,15 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="MessageTemplateCache.cs" />
+    <Compile Include="SerilogLoggingAdapter.cs" />
+    <Compile Include="SerilogLoggingAdapterExtensions.cs" />
     <Compile Include="SerilogLogMessageFormatter.cs" />
     <Compile Include="SerilogLogger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Akka.Logger.Serilog.nuspec" />
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Akka.Logger.Serilog/SerilogLoggingAdapter.cs
+++ b/src/Akka.Logger.Serilog/SerilogLoggingAdapter.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Akka.Event;
+using Serilog.Core;
+using Serilog.Core.Enrichers;
+
+namespace Akka.Logger.Serilog
+{
+    public class SerilogLoggingAdapter : ILoggingAdapter
+    {
+        private readonly ILoggingAdapter adapter;
+        private readonly IDictionary<string, ILogEventEnricher> enrichers = new Dictionary<string, ILogEventEnricher>();
+
+        public SerilogLoggingAdapter(ILoggingAdapter adapter)
+        {
+            this.adapter = adapter;
+        }
+
+        /// <summary>
+        /// Check to determine whether the <see cref="F:Akka.Event.LogLevel.DebugLevel" /> is enabled.
+        /// </summary>
+        public bool IsDebugEnabled => adapter.IsDebugEnabled;
+
+        /// <summary>
+        /// Check to determine whether the <see cref="F:Akka.Event.LogLevel.InfoLevel" /> is enabled.
+        /// </summary>
+        public bool IsInfoEnabled => adapter.IsInfoEnabled;
+
+        /// <summary>
+        /// Check to determine whether the <see cref="F:Akka.Event.LogLevel.WarningLevel" /> is enabled.
+        /// </summary>
+        public bool IsWarningEnabled => adapter.IsWarningEnabled;
+
+        /// <summary>
+        /// Check to determine whether the <see cref="F:Akka.Event.LogLevel.ErrorLevel" /> is enabled.
+        /// </summary>
+        public bool IsErrorEnabled => adapter.IsErrorEnabled;
+
+        /// <summary>Determines whether a specific log level is enabled.</summary>
+        /// <param name="logLevel">The log level that is being checked.</param>
+        /// <returns><c>true</c> if the specified level is enabled; otherwise <c>false</c>.</returns>
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return adapter.IsEnabled(logLevel);
+        }
+
+        /// <summary>
+        /// Logs a <see cref="F:Akka.Event.LogLevel.DebugLevel" /> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public virtual void Debug(string format, params object[] args)
+        {
+            adapter.Debug(format, BuildArgs(args));
+        }
+
+        /// <summary>
+        /// Logs a <see cref="F:Akka.Event.LogLevel.InfoLevel" /> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public virtual void Info(string format, params object[] args)
+        {
+            adapter.Info(format, BuildArgs(args));
+        }
+
+        /// <summary>
+        /// Obsolete. Use <see cref="M:Akka.Event.ILoggingAdapter.Warning(System.String,System.Object[])" /> instead!
+        /// </summary>
+        /// <param name="format">N/A</param>
+        /// <param name="args">N/A</param>
+        public virtual void Warn(string format, params object[] args)
+        {
+            adapter.Warning(format, BuildArgs(args));
+        }
+
+        /// <summary>
+        /// Logs a <see cref="F:Akka.Event.LogLevel.WarningLevel" /> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public virtual void Warning(string format, params object[] args)
+        {
+            adapter.Warning(format, BuildArgs(args));
+        }
+
+        /// <summary>
+        /// Logs a <see cref="F:Akka.Event.LogLevel.ErrorLevel" /> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public virtual void Error(string format, params object[] args)
+        {
+            adapter.Error(format, BuildArgs(args));
+        }
+
+        /// <summary>
+        /// Logs a <see cref="F:Akka.Event.LogLevel.ErrorLevel" /> message and associated exception.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public virtual void Error(Exception cause, string format, params object[] args)
+        {
+            adapter.Error(cause, format, BuildArgs(args));
+        }
+
+        /// <summary>Logs a message with a specified level.</summary>
+        /// <param name="logLevel">The level used to log the message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public virtual void Log(LogLevel logLevel, string format, params object[] args)
+        {
+            adapter.Log(logLevel, format, BuildArgs(args));
+        }
+
+        public ILoggingAdapter SetContextProperty(string name, object value, bool destructureObjects = false)
+        {
+            enrichers.Add(name, new PropertyEnricher(name, value, destructureObjects));
+            return this;
+        }
+
+        private object[] BuildArgs(IEnumerable<object> args)
+        {
+            var newArgs = args.ToList();
+            newArgs.AddRange(enrichers.Select(enricher => enricher.Value));
+            return newArgs.ToArray();
+        }
+    }
+}

--- a/src/Akka.Logger.Serilog/SerilogLoggingAdapterExtensions.cs
+++ b/src/Akka.Logger.Serilog/SerilogLoggingAdapterExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Akka.Actor;
+using Akka.Event;
+
+namespace Akka.Logger.Serilog
+{
+    public static class SerilogLoggingAdapterExtensions
+    {
+        /// <summary>
+        /// Create a logger that enriches log events with the specified property.
+        /// </summary>
+        /// <param name="adapter">ILoggingAdapter instance</param>
+        /// <param name="propertyName">The name of the property. Must be non-empty.</param>
+        /// <param name="value">The property value.</param>
+        /// <param name="destructureObjects">If true, the value will be serialized as a structured object if possible; if false, the object will be recorded as a scalar or simple array.</param>
+        public static ILoggingAdapter ForContext(this ILoggingAdapter adapter, string propertyName, object value, bool destructureObjects = false)
+        {
+            var customAdapter = adapter as SerilogLoggingAdapter;
+            return customAdapter == null ? adapter : customAdapter.SetContextProperty(propertyName, value, destructureObjects);
+        }
+
+        /// <summary>
+        /// Creates a new logging adapter using the specified context's event stream.
+        /// </summary>
+        /// <param name="context">The context used to configure the logging adapter.</param>
+        /// <returns>The newly created logging adapter.</returns>
+        public static ILoggingAdapter GetLogger<T>(this IActorContext context)
+            where T : class, ILoggingAdapter
+        {
+            var logSource = context.Self.ToString();
+            var logClass = context.Props.Type;
+
+            return Activator.CreateInstance(typeof(T), new BusLogging(context.System.EventStream, logSource, logClass, new SerilogLogMessageFormatter())) as T;
+        }
+    }
+}

--- a/src/Akka.Logger.Serilog/app.config
+++ b/src/Akka.Logger.Serilog/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Akka.Logger.Serilog/packages.config
+++ b/src/Akka.Logger.Serilog/packages.config
@@ -3,5 +3,5 @@
   <package id="Akka" version="1.1.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="Serilog" version="2.4.0" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
One particular feature I was missing when logging thru serilog with Akka was the ability to use [contextual logging](https://nblumhardt.com/2016/08/context-and-correlation-structured-logging-concepts-in-net-5/). Specifically in scenarios where you want to correlate all messages inside a FSM with some sort of correlation id.

Now, I don't like a bit that I had to alter the public API and add an extension method `Context.GetLogger<T>()` to make this work, but I couldn't find another way around it since Akka doesn't allow you to set your own custom ILoggingAdapter thru configuration (or hopefully I'm missing something).