### PR TITLE
Fix issue where trivial log messages are output wrapped in quotes

### DIFF
--- a/src/Akka.Logger.Serilog/SerilogLogger.cs
+++ b/src/Akka.Logger.Serilog/SerilogLogger.cs
@@ -27,7 +27,7 @@ namespace Akka.Logger.Serilog
         private static string GetFormat(object message)
         {
             var logMessage = message as LogMessage;
-            return logMessage != null ? logMessage.Format : "{Message}";
+            return logMessage != null ? logMessage.Format : "{Message:l}";
         }
 
         private static object[] GetArgs(object message)


### PR DESCRIPTION
Serilog, by default, wraps string properties in quotes to communicate the underlying data type. Adding the Serilog specific 'l' format string to the property instructs Serilog to treat the property as a literal string and output the value without wrapping it in quotes.

Since we are wrapping trivial log messages in a single token message template (as is best practice in this case to avoid thrashing the message template cache), it makes sense to drop the surrounding quotes. The only purpose of the wrapping quotes is to communicate type information in the context of a meaningful log event property, and we are wrapping a message in a token with the understanding that our input has no meaningful event properties.