### PR TITLE
bumped version to v1.3.3 (matches current Akka.NET)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 1.3.0 January 27 2018 ####
+#### 1.3.3 January 27 2018 ####
 
 Removed SerilogLogMessageFormatter since its no longer needed
 Support for Akka 1.3.3


### PR DESCRIPTION
Apparently we already had a v1.3.0 on NuGet, so I bumped the version number to match the current Akka.NET NuGet package just for the sake of consistency.

Closed down the old PR because my `dev` branch had some unmerged stuff in it. Cleaned this one up.