### PR TITLE
added v1.3.9 release notes and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the Serilog integration plugin for Akka.NET. Please check out our [documentation](http://getakka.net/articles/utilities/serilog.html) on how to get the most out of this plugin.
 
-Targets Serilog 2.6.0.
+Targets Serilog 2.7.1.
 
 ### Semantic Logging Syntax
 If you intend on using any of the Serilog semantic logging formats in your logging strings, __you need to use the SerilogLoggingAdapter__ inside your instrumented code or there could be elsewhere inside parts of your `ActorSystem`:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.3.9 August 23 2018 ####
+* [Fixed: Regression: ForContext API doesn't apply changes](https://github.com/akkadotnet/Akka.Logger.Serilog/issues/51)
+* Upgraded to Akka.NET v1.3.9.
+* Upgraded to Serilog v2.7.1.
+
 #### 1.3.6 April 28 2018 ####
 * Restored `SerilogLogMessageFormatter` in order to fix [Bug: `LogEvent.ToString()` blows up when using Serilog semantic formatting](https://github.com/akkadotnet/Akka.Logger.Serilog/issues/43). 
 * Upgraded to [Akka.NET v1.3.6](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.6).

--- a/src/common.props
+++ b/src/common.props
@@ -3,15 +3,10 @@
     <PackageTags>akka;actors;actor model;Akka;concurrency;serilog</PackageTags>
     <Copyright>Copyright © 2013-2018 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <PackageReleaseNotes>Restored `SerilogLogMessageFormatter` in order to fix [Bug: `LogEvent.ToString()` blows up when using Serilog semantic formatting](https://github.com/akkadotnet/Akka.Logger.Serilog/issues/43).
-Upgraded to [Akka.NET v1.3.6](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.6).
-If you intend on using any of the Serilog semantic logging formats in your logging strings, __you need to use the SerilogLoggingAdapter__ inside your instrumented code or there could be elsewhere inside parts of your `ActorSystem`:
-```csharp
-var log = Context.GetLogger&lt;SerilogLoggingAdapter&gt;(); // correct
-log.Info("My boss makes me use {semantic} logging", "semantic"); // serilog semantic logging format
-```
-This will allow all logging events to be consumed anywhere inside the `ActorSystem`, including places like the Akka.NET TestKit, without throwing `FormatException`s when they encounter semantic logging syntax outside of the `SerilogLogger`.</PackageReleaseNotes>
-    <VersionPrefix>1.3.6</VersionPrefix>
+    <PackageReleaseNotes>[Fixed: Regression: ForContext API doesn't apply changes](https://github.com/akkadotnet/Akka.Logger.Serilog/issues/51)
+Upgraded to Akka.NET v1.3.9.
+Upgraded to Serilog v2.7.1.</PackageReleaseNotes>
+    <VersionPrefix>1.3.9</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Logger.Serilog</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Logger.Serilog/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
#### 1.3.9 August 23 2018 ####
* [Fixed: Regression: ForContext API doesn't apply changes](https://github.com/akkadotnet/Akka.Logger.Serilog/issues/51)
* Upgraded to Akka.NET v1.3.9.
* Upgraded to Serilog v2.7.1.
