### PR TITLE
Akka.Logger.Serilog v1.3.9 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the Serilog integration plugin for Akka.NET. Please check out our [documentation](http://getakka.net/articles/utilities/serilog.html) on how to get the most out of this plugin.
 
-Targets Serilog 2.6.0.
+Targets Serilog 2.7.1.
 
 ### Semantic Logging Syntax
 If you intend on using any of the Serilog semantic logging formats in your logging strings, __you need to use the SerilogLoggingAdapter__ inside your instrumented code or there could be elsewhere inside parts of your `ActorSystem`:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.3.9 August 23 2018 ####
+* [Fixed: Regression: ForContext API doesn't apply changes](https://github.com/akkadotnet/Akka.Logger.Serilog/issues/51)
+* Upgraded to Akka.NET v1.3.9.
+* Upgraded to Serilog v2.7.1.
+
 #### 1.3.6 April 28 2018 ####
 * Restored `SerilogLogMessageFormatter` in order to fix [Bug: `LogEvent.ToString()` blows up when using Serilog semantic formatting](https://github.com/akkadotnet/Akka.Logger.Serilog/issues/43). 
 * Upgraded to [Akka.NET v1.3.6](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.6).

--- a/src/Akka.Logger.Serilog.Tests/Akka.Logger.Serilog.Tests.csproj
+++ b/src/Akka.Logger.Serilog.Tests/Akka.Logger.Serilog.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.6" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.9" />
     <PackageReference Include="FluentAssertions" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />

--- a/src/Akka.Logger.Serilog.Tests/ForContextSpecs.cs
+++ b/src/Akka.Logger.Serilog.Tests/ForContextSpecs.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using FluentAssertions;
+using Serilog;
+using Serilog.Events;
+using Xunit;
+using Xunit.Abstractions;
+using LogEvent = Akka.Event.LogEvent;
+
+namespace Akka.Logger.Serilog.Tests
+{
+    public class ForContextSpecs : TestKit.Xunit2.TestKit
+    {
+        public static readonly Config Config = @"akka.loglevel = DEBUG
+                                                 akka.loggers=[""Akka.Logger.Serilog.SerilogLogger, Akka.Logger.Serilog""]";
+        private ILoggingAdapter _loggingAdapter;
+        private readonly TestSink _sink = new TestSink();
+
+        public ForContextSpecs(ITestOutputHelper helper) : base(Config, output: helper)
+        {
+            global::Serilog.Log.Logger = new LoggerConfiguration()
+                .WriteTo.Sink(_sink)
+                .MinimumLevel.Information()
+                .CreateLogger();
+
+            var logSource = Sys.Name;
+            var logClass = typeof(ActorSystem);
+
+            _loggingAdapter = new SerilogLoggingAdapter(Sys.EventStream, logSource, logClass);
+        }
+
+        [Fact]
+        public void ShouldPassAlongAdditionalContext()
+        {
+            var traceId = Guid.NewGuid();
+            var spanId = Guid.NewGuid();
+            var context1 = _loggingAdapter.ForContext("traceId", traceId);
+            var context2 = context1.ForContext("spanId", spanId);
+
+            _sink.Clear();
+            AwaitCondition(() => _sink.Writes.Count == 0);
+
+            context1.Info("hi");
+            AwaitCondition(() => _sink.Writes.Count == 1);
+
+            _sink.Writes.TryDequeue(out var logEvent).Should().BeTrue();
+            logEvent.Level.Should().Be(LogEventLevel.Information);
+            logEvent.Properties.ContainsKey("traceId").Should().BeTrue();
+            logEvent.Properties["traceId"].ToString().Should().BeEquivalentTo(traceId.ToString());
+
+            _sink.Clear();
+            AwaitCondition(() => _sink.Writes.Count == 0);
+
+            context2.Info("bye");
+
+            AwaitCondition(() => _sink.Writes.Count == 1);
+
+            _sink.Writes.TryDequeue(out var logEvent2).Should().BeTrue();
+
+            logEvent2.Level.Should().Be(LogEventLevel.Information);
+
+            // needs to still have the context from context1
+            logEvent2.Properties.ContainsKey("traceId").Should().BeTrue();
+            logEvent2.Properties["traceId"].ToString().Should().BeEquivalentTo(traceId.ToString());
+
+            // and its own context from context2
+            logEvent2.Properties.ContainsKey("spanId").Should().BeTrue();
+            logEvent2.Properties["spanId"].ToString().Should().BeEquivalentTo(spanId.ToString());
+        }
+
+        [Fact]
+        public void ShouldPassAlongAdditionalContextWorkaround()
+        {
+            var traceId = Guid.NewGuid();
+            var spanId = Guid.NewGuid();
+            var context1 = (SerilogLoggingAdapter)_loggingAdapter.ForContext("traceId", traceId);
+            var context2 = (SerilogLoggingAdapter)context1.ForContext("spanId", spanId);
+
+            _sink.Clear();
+            AwaitCondition(() => _sink.Writes.Count == 0);
+
+            context1.Info("hi");
+            AwaitCondition(() => _sink.Writes.Count == 1);
+
+            _sink.Writes.TryDequeue(out var logEvent).Should().BeTrue();
+            logEvent.Level.Should().Be(LogEventLevel.Information);
+            logEvent.Properties.ContainsKey("traceId").Should().BeTrue();
+            logEvent.Properties["traceId"].ToString().Should().BeEquivalentTo(traceId.ToString());
+
+            _sink.Clear();
+            AwaitCondition(() => _sink.Writes.Count == 0);
+
+            context2.Info("bye");
+
+            AwaitCondition(() => _sink.Writes.Count == 1);
+
+            _sink.Writes.TryDequeue(out var logEvent2).Should().BeTrue();
+
+            logEvent2.Level.Should().Be(LogEventLevel.Information);
+
+            // needs to still have the context from context1
+            logEvent2.Properties.ContainsKey("traceId").Should().BeTrue();
+            logEvent2.Properties["traceId"].ToString().Should().BeEquivalentTo(traceId.ToString());
+
+            // and its own context from context2
+            logEvent2.Properties.ContainsKey("spanId").Should().BeTrue();
+            logEvent2.Properties["spanId"].ToString().Should().BeEquivalentTo(spanId.ToString());
+
+        }
+    }
+}
+
+
+

--- a/src/Akka.Logger.Serilog.Tests/TestSink.cs
+++ b/src/Akka.Logger.Serilog.Tests/TestSink.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Concurrent;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Akka.Logger.Serilog.Tests
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Basic concurrent sink implementation for testing the final output from Serilog
+    /// </summary>
+    public sealed class TestSink : ILogEventSink
+    {
+        public ConcurrentQueue<global::Serilog.Events.LogEvent> Writes { get; private set; } = new ConcurrentQueue<global::Serilog.Events.LogEvent>();
+
+        /// <summary>
+        /// Resets the contents of the queue
+        /// </summary>
+        public void Clear()
+        {
+            Writes = new ConcurrentQueue<LogEvent>();
+        }
+
+        public void Emit(global::Serilog.Events.LogEvent logEvent)
+        {
+            Writes.Enqueue(logEvent);
+        }
+    }
+}

--- a/src/Akka.Logger.Serilog/Akka.Logger.Serilog.csproj
+++ b/src/Akka.Logger.Serilog/Akka.Logger.Serilog.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.3.6" />
+    <PackageReference Include="Akka" Version="1.3.9" />
     <PackageReference Include="Serilog" Version="2.6.0" />
   </ItemGroup>
 

--- a/src/Akka.Logger.Serilog/Akka.Logger.Serilog.csproj
+++ b/src/Akka.Logger.Serilog/Akka.Logger.Serilog.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="Akka" Version="1.3.9" />
-    <PackageReference Include="Serilog" Version="2.6.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.Logger.Serilog/SerilogLoggingAdapter.cs
+++ b/src/Akka.Logger.Serilog/SerilogLoggingAdapter.cs
@@ -42,7 +42,7 @@ namespace Akka.Logger.Serilog
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public new void Debug(string format, params object[] args)
+        public override void Debug(string format, params object[] args)
         {
             base.Debug(format, BuildArgs(args));
         }
@@ -52,7 +52,7 @@ namespace Akka.Logger.Serilog
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public new void Info(string format, params object[] args)
+        public override void Info(string format, params object[] args)
         {
             base.Info(format, BuildArgs(args));
         }
@@ -60,9 +60,9 @@ namespace Akka.Logger.Serilog
         /// <summary>
         /// Obsolete. Use <see cref="M:Akka.Event.ILoggingAdapter.Warning(System.String,System.Object[])" /> instead!
         /// </summary>
-        /// <param name="format">N/A</param>
-        /// <param name="args">N/A</param>
-        public new void Warn(string format, params object[] args)
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public override void Warn(string format, params object[] args)
         {
             base.Warning(format, BuildArgs(args));
         }
@@ -72,7 +72,7 @@ namespace Akka.Logger.Serilog
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public new void Warning(string format, params object[] args)
+        public override void Warning(string format, params object[] args)
         {
             base.Warning(format, BuildArgs(args));
         }
@@ -82,7 +82,7 @@ namespace Akka.Logger.Serilog
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public new void Error(string format, params object[] args)
+        public override void Error(string format, params object[] args)
         {
             base.Error(format, BuildArgs(args));
         }
@@ -93,7 +93,7 @@ namespace Akka.Logger.Serilog
         /// <param name="cause">The exception associated with this message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public new void Error(Exception cause, string format, params object[] args)
+        public override void Error(Exception cause, string format, params object[] args)
         {
             base.Error(cause, format, BuildArgs(args));
         }
@@ -102,7 +102,7 @@ namespace Akka.Logger.Serilog
         /// <param name="logLevel">The level used to log the message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public new void Log(LogLevel logLevel, string format, params object[] args)
+        public override void Log(LogLevel logLevel, string format, params object[] args)
         {
             base.Log(logLevel, format, BuildArgs(args));
         }

--- a/src/Akka.Logger.Serilog/SerilogLoggingAdapterExtensions.cs
+++ b/src/Akka.Logger.Serilog/SerilogLoggingAdapterExtensions.cs
@@ -15,8 +15,7 @@ namespace Akka.Logger.Serilog
         /// <param name="destructureObjects">If true, the value will be serialized as a structured object if possible; if false, the object will be recorded as a scalar or simple array.</param>
         public static ILoggingAdapter ForContext(this ILoggingAdapter adapter, string propertyName, object value, bool destructureObjects = false)
         {
-            var customAdapter = adapter as SerilogLoggingAdapter;
-            return customAdapter == null ? adapter : customAdapter.SetContextProperty(propertyName, value, destructureObjects);
+            return !(adapter is SerilogLoggingAdapter customAdapter) ? adapter : customAdapter.SetContextProperty(propertyName, value, destructureObjects);
         }
 
         /// <summary>

--- a/src/common.props
+++ b/src/common.props
@@ -3,15 +3,10 @@
     <PackageTags>akka;actors;actor model;Akka;concurrency;serilog</PackageTags>
     <Copyright>Copyright © 2013-2018 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <PackageReleaseNotes>Restored `SerilogLogMessageFormatter` in order to fix [Bug: `LogEvent.ToString()` blows up when using Serilog semantic formatting](https://github.com/akkadotnet/Akka.Logger.Serilog/issues/43).
-Upgraded to [Akka.NET v1.3.6](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.6).
-If you intend on using any of the Serilog semantic logging formats in your logging strings, __you need to use the SerilogLoggingAdapter__ inside your instrumented code or there could be elsewhere inside parts of your `ActorSystem`:
-```csharp
-var log = Context.GetLogger&lt;SerilogLoggingAdapter&gt;(); // correct
-log.Info("My boss makes me use {semantic} logging", "semantic"); // serilog semantic logging format
-```
-This will allow all logging events to be consumed anywhere inside the `ActorSystem`, including places like the Akka.NET TestKit, without throwing `FormatException`s when they encounter semantic logging syntax outside of the `SerilogLogger`.</PackageReleaseNotes>
-    <VersionPrefix>1.3.6</VersionPrefix>
+    <PackageReleaseNotes>[Fixed: Regression: ForContext API doesn't apply changes](https://github.com/akkadotnet/Akka.Logger.Serilog/issues/51)
+Upgraded to Akka.NET v1.3.9.
+Upgraded to Serilog v2.7.1.</PackageReleaseNotes>
+    <VersionPrefix>1.3.9</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Logger.Serilog</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Logger.Serilog/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
#### 1.3.9 August 23 2018 ####
* [Fixed: Regression: ForContext API doesn't apply changes](https://github.com/akkadotnet/Akka.Logger.Serilog/issues/51)
* Upgraded to Akka.NET v1.3.9.
* Upgraded to Serilog v2.7.1.