### PR TITLE
Fix issue where ActorPath is used as SourceContext rather than ClassName as is normal in Serilog

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.3.11 February 05 2020 ####
+
+* Breaking change [Fixed: SourceContext should be set consistent with Serilog expectations](https://github.com/akkadotnet/Akka.Logger.Serilog/issues/78)
+
 #### 1.3.10 October 05 2019 ####
 * Upgraded to Serilog v2.9.0
 * Upgraded to Akka 1.3.15

--- a/src/Akka.Logger.Serilog/SerilogLogger.cs
+++ b/src/Akka.Logger.Serilog/SerilogLogger.cs
@@ -10,6 +10,7 @@ using Akka.Actor;
 using Akka.Dispatch;
 using Akka.Event;
 using Serilog;
+using Serilog.Core;
 using Serilog.Core.Enrichers;
 
 namespace Akka.Logger.Serilog
@@ -37,11 +38,12 @@ namespace Akka.Logger.Serilog
         }
 
         private static ILogger GetLogger(LogEvent logEvent) {
-            var logger = Log.Logger.ForContext("SourceContext", Context.Sender.Path);
-            logger = logger
-                .ForContext("Timestamp", logEvent.Timestamp)
-                .ForContext("LogSource", logEvent.LogSource)
-                .ForContext("Thread", logEvent.Thread.ManagedThreadId.ToString().PadLeft(4, '0'));
+			var logger = Log.Logger
+				.ForContext(Constants.SourceContextPropertyName, logEvent.LogClass.FullName)
+				.ForContext("ActorPath", Context.Sender.Path)
+				.ForContext("Timestamp", logEvent.Timestamp)
+				.ForContext("LogSource", logEvent.LogSource)
+				.ForContext("Thread", logEvent.Thread.ManagedThreadId.ToString().PadLeft( 4, '0' ));
 
             var logMessage = logEvent.Message as LogMessage;
             if (logMessage != null)


### PR DESCRIPTION
In Serilog the SourceContext property is Class.FullName. Features like minimum overrides work with this expectation.

Closes #78