### PR TITLE
Make logs without parameter follows serilog convention

### DIFF
--- a/src/Akka.Logger.Serilog/SerilogLogger.cs
+++ b/src/Akka.Logger.Serilog/SerilogLogger.cs
@@ -29,13 +29,15 @@ namespace Akka.Logger.Serilog
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static string GetFormat(object message)
         {
-            return message is LogMessage logMessage ? logMessage.Format : "{Message:l}";
+            return message is LogMessage logMessage 
+                ? logMessage.Format 
+                : message is string format ? format : "{Message:l}";
         }
 
         private static object[] GetArgs(object message)
         {
             var logMessage = message as LogMessage;
-            return logMessage?.Parameters().Where(a => a is not PropertyEnricher).ToArray() ?? new[] { message };
+            return logMessage?.Parameters().Where(a => a is not PropertyEnricher).ToArray() ?? System.Array.Empty<object>();
         }
 
         private static ILogger GetLogger(LogEvent logEvent) {


### PR DESCRIPTION
Fixes #

## Changes

Currently the Akka.Logger.Serilog logs msg without parameter is highlited in output console, 
but conventionaly it's a normal string with Serilog. 

with these code
``` csharp
        var log = Context.GetLogger();
        log.Info("hello");  
        log.Info("hello {What}", "world");  
```

The following picture shows current out and expected output in Rider
Current:
![akka serilog current output](https://user-images.githubusercontent.com/846278/222038537-e44a5b45-57d8-4d69-8d2c-57d618ee6e54.png)
Expected:
![akka serilog expected output](https://user-images.githubusercontent.com/846278/222038556-b000ca36-c91f-49ef-a793-d7adcb3047b6.png)



## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 
No

### This PR's Benchmarks
No
