### PR TITLE
changing formatter priv ctor to public, needed to configure serilog programmatically

### DIFF
--- a/src/Akka.Logger.Serilog/SerilogLogMessageFormatter.cs
+++ b/src/Akka.Logger.Serilog/SerilogLogMessageFormatter.cs
@@ -20,7 +20,7 @@ namespace Akka.Logger.Serilog
         /// <summary>
         /// Initializes a new instance of the <see cref="SerilogLogMessageFormatter"/> class.
         /// </summary>
-        private SerilogLogMessageFormatter()
+        public SerilogLogMessageFormatter()
         {
             _templateCache = new MessageTemplateCache(new MessageTemplateParser());
         }


### PR DESCRIPTION
Fixes #217 

## Changes

Changing SerilogLogMessageFormatter ctor from private to public to be able to use in config like so
```
configBuilder.LogMessageFormatter = typeof(SerilogLogMessageFormatter); 
```
Otherwise this exception is thrown at runtime
Akka.Configuration.ConfigurationException: 'LogMessageFormatter Type must have an empty constructor'

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #217
* [ ] Changes in public API reviewed, if any.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
