### PR TITLE
Update RELEASE_NOTES.md for 1.5.7 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+#### 1.5.7 May 19 2023 ####
+
+* [Update Akka.NET to 1.5.7](https://github.com/akkadotnet/akka.net/releases/tag/1.5.7)
+* [Fix SerilogLogMessageFormatter duplicate key exception bug](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/228)
+* [Add log event property enricher support](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/229)
+* [Fix backward compatibility issue](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/230)
+
 #### 1.5.0.1 March 15 2023 ####
 
 * [Fixed: `SerilogMessageFormatter` CTOR is `private`, can't be instantiated as the default `LogMessageFormatter`](https://github.com/akkadotnet/Akka.Logger.Serilog/issues/217)


### PR DESCRIPTION
## 1.5.7 May 19 2023

* [Update Akka.NET to 1.5.7](https://github.com/akkadotnet/akka.net/releases/tag/1.5.7)
* [Fix SerilogLogMessageFormatter duplicate key exception bug](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/228)
* [Add log event property enricher support](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/229)
* [Fix backward compatibility issue](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/230)
