### PR TITLE
Akka.Hosting `LoggerConfigBuilder`

### DIFF
--- a/src/Akka.Logger.Serilog/Akka.Logger.Serilog.csproj
+++ b/src/Akka.Logger.Serilog/Akka.Logger.Serilog.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" />
-    <PackageReference Include="Akka" />
+    <PackageReference Include="Akka.Hosting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Akka.Logger.Serilog/SerilogAkkaHostingExtensions.cs
+++ b/src/Akka.Logger.Serilog/SerilogAkkaHostingExtensions.cs
@@ -1,0 +1,31 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SerilogAkkaHostingExtensions.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Hosting;
+
+namespace Akka.Logger.Serilog;
+
+/// <summary>
+/// Extension methods for configuring Serilog as the default logger for Akka.NET.
+/// </summary>
+public static class SerilogAkkaHostingExtensions
+{
+    /// <summary>
+    /// Adds Serilog one of the default loggers for the Akka.NET actor system and enables
+    /// Serilog-style semantic logging formatting for all log messages.
+    /// </summary>
+    /// <param name="configBuilder">The Akka.Hosting <see cref="LoggerConfigBuilder"/> - call <see cref="AkkaConfigurationBuilder.WithLogging"/></param>
+    /// <param name="enableSerilogFormatter">Defaults to <c>true</c> - enables the <see cref="SerilogLogMessageFormatter"/> to be used by default.</param>
+    /// <returns></returns>
+    public static LoggerConfigBuilder AddSerilogLogging(this LoggerConfigBuilder configBuilder, bool enableSerilogFormatter = true)
+    {
+        configBuilder.AddLogger<SerilogLogger>();
+        
+        if(enableSerilogFormatter)
+            configBuilder.WithDefaultLogMessageFormatter<SerilogLogMessageFormatter>();
+        return configBuilder;
+    }
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,9 +12,9 @@
     <LangVersion>10</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaVersion>1.5.14</AkkaVersion>
-    <AkkaHostingVersion>1.5.13</AkkaHostingVersion>
-    <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
+    <AkkaVersion>1.5.20</AkkaVersion>
+    <AkkaHostingVersion>1.5.20</AkkaHostingVersion>
+    <NetCoreTestVersion>net8.0</NetCoreTestVersion>
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
   </PropertyGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,8 +6,8 @@
   <ItemGroup>
     <PackageVersion Include="Akka" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Cluster" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
-    
     <PackageVersion Include="Serilog" Version="2.12.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
@@ -18,7 +18,7 @@
     <PackageVersion Include="xunit" Version="2.6.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka.TestKit.Xunit2" Version="1.5.20" />
     <PackageVersion Include="NBench" Version="2.0.1" />
   </ItemGroup>
   <!-- SourceLink support for all Akka.NET projects -->


### PR DESCRIPTION
## Changes

Added some convenience methods for configuring `SerilogLogger` with Akka.Hosting automatically - and enabling the `SerilogLogMessageFormatter` to be the default message formatter for the `ActorSystem`.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
