### PR TITLE
implicitly convert regular `BusLogger` to `SerilogLoggingAdapter` when `ForContext` is called

### DIFF
--- a/Akka.Logger.Serilog.sln
+++ b/Akka.Logger.Serilog.sln
@@ -17,6 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{489D8D37
 		build.sh = build.sh
 		src\Directory.Build.props = src\Directory.Build.props
 		src\Directory.Packages.props = src\Directory.Packages.props
+		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{28CDBE4C-053C-4CD4-B5D2-4DF529922916}"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ log.Info(
 
 This log entry will have "County" and "Country" properties added to it.
 
+### Automatically Convert `ILoggingAdapter` into `SerilogLoggingAdapter`
+
+As of Akka.Logger.Serilog v1.5.22, you can now do the following:
+
+```csharp
+var log = Context.GetLogger()
+    .ForContext("Address", "No. 4 Privet Drive")
+    .ForContext("Town", "Little Whinging")
+    .ForContext("County", "Surrey")
+    .ForContext("Country", "England");
+log.Info("My boss makes me use {Semantic} logging", "semantic");
+```
+
+And it will work without having to explicitly call `Context.GetLogger<SerilogLoggingAdapter>()` first.
+
 ## Building this solution
 To run the build script associated with this solution, execute the following:
 
@@ -73,35 +88,3 @@ c:\> build.sh all
 If you need any information on the supported commands, please execute the `build.[cmd|sh] help` command.
 
 This build script is powered by [FAKE](https://fake.build/); please see their API documentation should you need to make any changes to the [`build.fsx`](build.fsx) file.
-
-### Conventions
-The attached build script will automatically do the following based on the conventions of the project names added to this project:
-
-* Any project name ending with `.Tests` will automatically be treated as a [XUnit2](https://xunit.github.io/) project and will be included during the test stages of this build script;
-* Any project name ending with `.Tests` will automatically be treated as a [NBench](https://github.com/petabridge/NBench) project and will be included during the test stages of this build script; and
-* Any project meeting neither of these conventions will be treated as a NuGet packaging target and its `.nupkg` file will automatically be placed in the `bin\nuget` folder upon running the `build.[cmd|sh] all` command.
-
-### DocFx for Documentation
-This solution also supports [DocFx](http://dotnet.github.io/docfx/) for generating both API documentation and articles to describe the behavior, output, and usages of your project. 
-
-All of the relevant articles you wish to write should be added to the `/docs/articles/` folder and any API documentation you might need will also appear there.
-
-All of the documentation will be statically generated and the output will be placed in the `/docs/_site/` folder. 
-
-#### Previewing Documentation
-To preview the documentation for this project, execute the following command at the root of this folder:
-
-```
-C:\> serve-docs.cmd
-```
-
-This will use the built-in `docfx.console` binary that is installed as part of the NuGet restore process from executing any of the usual `build.cmd` or `build.sh` steps to preview the fully-rendered documentation. For best results, do this immediately after calling `build.cmd buildRelease`.
-
-### Release Notes, Version Numbers, Etc
-This project will automatically populate its release notes in all of its modules via the entries written inside [`RELEASE_NOTES.md`](RELEASE_NOTES.md) and will automatically update the versions of all assemblies and NuGet packages via the metadata included inside [`common.props`](src/common.props).
-
-If you add any new projects to the solution created with this template, be sure to add the following line to each one of them in order to ensure that you can take advantage of `common.props` for standardization purposes:
-
-```
-<Import Project="..\common.props" />
-```

--- a/src/Akka.Logger.Serilog.Tests/ForContextSpecs.cs
+++ b/src/Akka.Logger.Serilog.Tests/ForContextSpecs.cs
@@ -22,6 +22,11 @@ namespace Akka.Logger.Serilog.Tests
         public static readonly Config Config = @"akka.loglevel = DEBUG
                                                  akka.loggers=[""Akka.Logger.Serilog.SerilogLogger, Akka.Logger.Serilog""]";
         private readonly ILoggingAdapter _loggingAdapter;
+        
+        /// <summary>
+        /// Used to test that https://github.com/akkadotnet/Akka.Logger.Serilog/issues/284 is fixed
+        /// </summary>
+        private readonly ILoggingAdapter _defaultLoggingAdapter;
         private readonly TestSink _sink = new TestSink();
 
         public ForContextSpecs(ITestOutputHelper helper) : base(Config, output: helper)
@@ -35,6 +40,63 @@ namespace Akka.Logger.Serilog.Tests
             var logClass = typeof(ActorSystem);
 
             _loggingAdapter = Sys.GetLogger<SerilogLoggingAdapter>(logSource, logClass);
+            _defaultLoggingAdapter = Sys.Log;
+        }
+        
+        /// <summary>
+        /// Used to test that https://github.com/akkadotnet/Akka.Logger.Serilog/issues/284 is fixed
+        /// </summary>
+        [Fact]
+        public void ShouldLogMessageWithContextPropertyDefaultLogger()
+        {
+	        var context = _defaultLoggingAdapter
+		        .ForContext("Address", "No. 4 Privet Drive")
+		        .ForContext("Town", "Little Whinging")
+		        .ForContext("County", "Surrey")
+		        .ForContext("Country", "England");
+
+	        _sink.Clear();
+	        AwaitCondition(() => _sink.Writes.Count == 0);
+
+	        context.Info("Hi {Person}", "Harry Potter");
+	        AwaitCondition(() => _sink.Writes.Count == 1);
+
+	        _sink.Writes.TryDequeue(out var logEvent).Should().BeTrue();
+	        logEvent.Level.Should().Be(LogEventLevel.Information);
+	        logEvent.RenderMessage().Should().Contain("Hi \"Harry Potter\"");
+	        logEvent.Properties.Should().ContainKeys("Person", "Address", "Town", "County", "Country");
+	        logEvent.Properties["Person"].ToString().Should().Be("\"Harry Potter\"");
+	        logEvent.Properties["Address"].ToString().Should().Be("\"No. 4 Privet Drive\"");
+	        logEvent.Properties["Town"].ToString().Should().Be("\"Little Whinging\"");
+	        logEvent.Properties["County"].ToString().Should().Be("\"Surrey\"");
+	        logEvent.Properties["Country"].ToString().Should().Be("\"England\"");
+        }
+
+        /// <summary>
+        /// Used to test that https://github.com/akkadotnet/Akka.Logger.Serilog/issues/284 is fixed
+        /// </summary>
+        [Fact]
+        public void ShouldLogMessageWithContextPropertyAndPropertyEnricherDefaultLogger()
+        {
+	        var context = _defaultLoggingAdapter
+		        .ForContext("Address", "No. 4 Privet Drive")
+		        .ForContext("Town", "Little Whinging");
+
+	        _sink.Clear();
+	        AwaitCondition(() => _sink.Writes.Count == 0);
+
+	        context.Info("Hi {Person}", "Harry Potter", new PropertyEnricher("County", "Surrey"), new PropertyEnricher("Country", "England"));
+	        AwaitCondition(() => _sink.Writes.Count == 1);
+
+	        _sink.Writes.TryDequeue(out var logEvent).Should().BeTrue();
+	        logEvent.Level.Should().Be(LogEventLevel.Information);
+	        logEvent.RenderMessage().Should().Contain("Hi \"Harry Potter\"");
+	        logEvent.Properties.Should().ContainKeys("Person", "Address", "Town", "County", "Country");
+	        logEvent.Properties["Person"].ToString().Should().Be("\"Harry Potter\"");
+	        logEvent.Properties["Address"].ToString().Should().Be("\"No. 4 Privet Drive\"");
+	        logEvent.Properties["Town"].ToString().Should().Be("\"Little Whinging\"");
+	        logEvent.Properties["County"].ToString().Should().Be("\"Surrey\"");
+	        logEvent.Properties["Country"].ToString().Should().Be("\"England\"");
         }
 
         [Fact]

--- a/src/Akka.Logger.Serilog/SerilogLoggingAdapter.cs
+++ b/src/Akka.Logger.Serilog/SerilogLoggingAdapter.cs
@@ -25,6 +25,9 @@ namespace Akka.Logger.Serilog
         }
     }
     
+    /// <summary>
+    /// Serilog logging adapter.
+    /// </summary>
     public class SerilogLoggingAdapter : LoggingAdapterBase
     {
         private readonly LoggingBus _bus;

--- a/src/Akka.Logger.Serilog/SerilogLoggingAdapterExtensions.cs
+++ b/src/Akka.Logger.Serilog/SerilogLoggingAdapterExtensions.cs
@@ -15,7 +15,18 @@ namespace Akka.Logger.Serilog
         /// <param name="destructureObjects">If true, the value will be serialized as a structured object if possible; if false, the object will be recorded as a scalar or simple array.</param>
         public static ILoggingAdapter ForContext(this ILoggingAdapter adapter, string propertyName, object value, bool destructureObjects = false)
         {
-            return adapter is not SerilogLoggingAdapter customAdapter ? adapter : customAdapter.SetContextProperty(propertyName, value, destructureObjects);
+            if(adapter is SerilogLoggingAdapter customAdapter)
+                return customAdapter.SetContextProperty(propertyName, value, destructureObjects);
+
+            if (adapter is BusLogging defaultAkkaAdapter)
+            {
+                var enrichedAdapter = new SerilogLoggingAdapter(defaultAkkaAdapter.Bus, defaultAkkaAdapter.LogSource, defaultAkkaAdapter.LogClass);
+                return enrichedAdapter.SetContextProperty(propertyName, value, destructureObjects);
+            }
+            
+            // log a warning if the adapter is not a SerilogLoggingAdapter or BusLogging
+            adapter.Warning($"Cannot enrich log event with property {propertyName} because the adapter is not a {typeof(SerilogLoggingAdapter)} or {typeof(BusLogging)}.");
+            return adapter;
         }
 
         /// <summary>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
     <LangVersion>10</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaVersion>1.5.14</AkkaVersion>
+    <AkkaVersion>1.5.22-beta1</AkkaVersion>
     <AkkaHostingVersion>1.5.13</AkkaHostingVersion>
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>


### PR DESCRIPTION
## Changes

close #284 - requires https://github.com/akkadotnet/akka.net/pull/7210 to be merged and Akka.NET v1.5.22 to get shipped.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #284
* [x] Changes in public API reviewed, if any.