### PR TITLE
upgraded to use `global.json` for setting .NET runtime versions

### DIFF
--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -15,6 +15,7 @@ jobs:
       - task: UseDotNet@2
         displayName: 'Use .NET SDK'
         inputs:
+          packageType: sdk
           useGlobalJson: true
       - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
         clean: false  # whether to fetch clean each time

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -12,15 +12,15 @@ jobs:
     pool:
       vmImage: ${{ parameters.vmImage }}
     steps:
+      - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+        clean: false  # whether to fetch clean each time
+        submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
+        persistCredentials: true
       - task: UseDotNet@2
         displayName: 'Use .NET SDK'
         inputs:
           packageType: sdk
           useGlobalJson: true
-      - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
-        clean: false  # whether to fetch clean each time
-        submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
-        persistCredentials: true
       # Linux or macOS
       - task: Bash@3 
         displayName: Linux / OSX Build

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -13,19 +13,9 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     steps:
       - task: UseDotNet@2
-        displayName: 'Use .NET 7 SDK'
+        displayName: 'Use .NET SDK'
         inputs:
-          version: 7.x
-      - task: UseDotNet@2
-        displayName: 'Use .NET Core Runtime 6'
-        inputs:
-          packageType: runtime
-          version: 6.x
-      - task: UseDotNet@2
-        displayName: 'Use .NET Core Runtime 3'
-        inputs:
-          packageType: runtime
-          version: 3.x
+          useGlobalJson: true
       - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
         clean: false  # whether to fetch clean each time
         submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules

--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -24,6 +24,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Use .NET SDK'
   inputs:
+    packageType: sdk
     useGlobalJson: true
 - task: BatchScript@1
   displayName: 'FAKE Build'

--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -21,6 +21,10 @@ variables:
     value: akkadotnet/Akka.Logger.Serilog #replace this
 
 steps:
+- checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+  clean: false  # whether to fetch clean each time
+  submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
+  persistCredentials: true
 - task: UseDotNet@2
   displayName: 'Use .NET SDK'
   inputs:

--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -22,20 +22,9 @@ variables:
 
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .NET 7 SDK 7.0.x'
+  displayName: 'Use .NET SDK'
   inputs:
-    version: 7.0.x
-- task: UseDotNet@2
-  displayName: 'Use .NET Core Runtime 6.0.x'
-  inputs:
-    packageType: runtime
-    version: 6.0.x
-- task: UseDotNet@2
-  displayName: 'Use .NET Core Runtime 3.1.x'
-  inputs:
-    packageType: runtime
-    version: 3.1.x
-
+    useGlobalJson: true
 - task: BatchScript@1
   displayName: 'FAKE Build'
   inputs:

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "rollForward": "latestMinor",
+    "version": "8.0.101"
+  }
+}

--- a/src/Akka.Logger.Serilog/Akka.Logger.Serilog.csproj
+++ b/src/Akka.Logger.Serilog/Akka.Logger.Serilog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(NetStandardLibVersion)</TargetFramework>
+    <TargetFrameworks>$(NetStandardLibVersion);net6.0</TargetFrameworks>
     <Description>Serilog logging adapter for Akka.NET.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageIcon>icon.png</PackageIcon>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <AkkaVersion>1.5.22</AkkaVersion>
     <AkkaHostingVersion>1.5.13</AkkaHostingVersion>
-    <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
+    <NetCoreTestVersion>net8.0</NetCoreTestVersion>
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,9 +3,8 @@
     <PackageTags>akka;actors;actor model;Akka;concurrency;serilog</PackageTags>
     <Copyright>Copyright © 2013-2023 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <PackageReleaseNotes>[Update Akka.NET to 1.5.12](https://github.com/akkadotnet/akka.net/releases/tag/1.5.12)
-[Fix Serilog message output bug](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/255)</PackageReleaseNotes>
-    <VersionPrefix>1.5.12</VersionPrefix>
+    <PackageReleaseNotes>[Update Akka.Hosting to 1.5.12.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.12.1)</PackageReleaseNotes>
+    <VersionPrefix>1.5.12.1</VersionPrefix>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Logger.Serilog</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <NoWarn>$(NoWarn);CS1591</NoWarn>


### PR DESCRIPTION
Upgrade to .NET 8 for testing and use .NET runtime versions specified in `global.json`