### PR TITLE
added v1.5.25 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
+#### 1.5.25 June 17 2024 ####
+
+* [Update Akka.Hosting to 1.5.25](https://github.com/akkadotnet/akka.net/releases/tag/1.5.25)
+* [implicitly convert regular `BusLogger` to `SerilogLoggingAdapter` when `ForContext` is called](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/285)
+
+As of Akka.Logger.Serilog v1.5.25, you can now do the following:
+
+```csharp
+var log = Context.GetLogger()
+    .ForContext("Address", "No. 4 Privet Drive")
+    .ForContext("Town", "Little Whinging")
+    .ForContext("County", "Surrey")
+    .ForContext("Country", "England");
+log.Info("My boss makes me use {Semantic} logging", "semantic");
+```
+
+And it will work without having to explicitly call `Context.GetLogger<SerilogLoggingAdapter>()` first.
+
 #### 1.5.12.1 August 31 2023 ####
 
 * [Update Akka.Hosting to 1.5.12.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.12.1)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,8 +3,19 @@
     <PackageTags>akka;actors;actor model;Akka;concurrency;serilog</PackageTags>
     <Copyright>Copyright © 2013-2023 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <PackageReleaseNotes>[Update Akka.Hosting to 1.5.12.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.12.1)</PackageReleaseNotes>
-    <VersionPrefix>1.5.12.1</VersionPrefix>
+    <PackageReleaseNotes>[Update Akka.Hosting to 1.5.25](https://github.com/akkadotnet/akka.net/releases/tag/1.5.25)
+[implicitly convert regular `BusLogger` to `SerilogLoggingAdapter` when `ForContext` is called](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/285)
+As of Akka.Logger.Serilog v1.5.25, you can now do the following:
+```csharp
+var log = Context.GetLogger()
+.ForContext("Address", "No. 4 Privet Drive")
+.ForContext("Town", "Little Whinging")
+.ForContext("County", "Surrey")
+.ForContext("Country", "England");
+log.Info("My boss makes me use {Semantic} logging", "semantic");
+```
+And it will work without having to explicitly call `Context.GetLogger&lt;SerilogLoggingAdapter&gt;()` first.</PackageReleaseNotes>
+    <VersionPrefix>1.5.25</VersionPrefix>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Logger.Serilog</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <NoWarn>$(NoWarn);CS1591</NoWarn>


### PR DESCRIPTION
#### 1.5.25 June 17 2024 ####

* [Update Akka.Hosting to 1.5.25](https://github.com/akkadotnet/akka.net/releases/tag/1.5.25)
* [implicitly convert regular `BusLogger` to `SerilogLoggingAdapter` when `ForContext` is called](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/285)

As of Akka.Logger.Serilog v1.5.25, you can now do the following:

```csharp
var log = Context.GetLogger()
    .ForContext("Address", "No. 4 Privet Drive")
    .ForContext("Town", "Little Whinging")
    .ForContext("County", "Surrey")
    .ForContext("Country", "England");
log.Info("My boss makes me use {Semantic} logging", "semantic");
```

And it will work without having to explicitly call `Context.GetLogger<SerilogLoggingAdapter>()` first.

close https://github.com/akkadotnet/Akka.Logger.Serilog/issues/290