### PR TITLE
Bump to Akka.NET 1.5.57

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
-#### 1.5.57-beta2 December 3rd 2025 ####
+#### 1.5.57 January 8 2026 ####
 
-* [Update Akka.NET to 1.5.57-beta2](https://github.com/akkadotnet/akka.net/releases/tag/1.5.57-beta2)
+* [Update Akka.NET to 1.5.57](https://github.com/akkadotnet/akka.net/releases/tag/1.5.57)
 * [Add semantic logging support for Akka.NET 1.5.56+](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/294)
 
 This release adds full semantic logging support, enabling Serilog to receive properly structured message templates and parameters instead of pre-formatted strings. This enhancement leverages Akka.NET's semantic logging APIs introduced in version 1.5.56, enabling richer structured logging capabilities.

--- a/src/Akka.Logger.Serilog.Tests/SemanticLoggingSpecs.cs
+++ b/src/Akka.Logger.Serilog.Tests/SemanticLoggingSpecs.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -65,203 +66,170 @@ akka.logger-formatter=""Akka.Logger.Serilog.SerilogLogMessageFormatter, Akka.Log
         public async Task NamedTemplatePropertiesTest()
         {
             _sink.Clear();
-            await _testKit.AwaitConditionAsync(() => _sink.Writes.Count == 0);
 
-            _loggingAdapter.Info("User {UserId} with email {Email} logged in", 12345, "user@example.com");
-
-            await _testKit.AwaitConditionAsync(() => 
-                AssertCondition(logEvent =>
-                {
-                    logEvent.Properties.Should().ContainKey("UserId");
-                    logEvent.Properties.Should().ContainKey("Email");
-                    logEvent.Properties["UserId"].ToString().Should().Be("12345");
-                    logEvent.Properties["Email"].ToString().Should().Be("\"user@example.com\"");
-                }));
+            // Log inside AwaitAssertAsync so retries send fresh messages
+            // (handles race where logger isn't subscribed to EventStream yet)
+            await _testKit.AwaitAssertAsync(() =>
+            {
+                _loggingAdapter.Info("User {UserId} with email {Email} logged in", 12345, "user@example.com");
+                var logEvent = GetMatchingLogEvent(e => e.Properties.ContainsKey("UserId"));
+                logEvent.Should().NotBeNull();
+                logEvent!.Properties["UserId"].ToString().Should().Be("12345");
+                logEvent.Properties["Email"].ToString().Should().Be("\"user@example.com\"");
+            });
         }
 
         [Fact(DisplayName = "Should extract positional template properties for Serilog")]
         public async Task PositionalTemplatePropertiesTest()
         {
             _sink.Clear();
-            await _testKit.AwaitConditionAsync(() => _sink.Writes.Count == 0);
 
-            _loggingAdapter.Info("User {0} logged in from {1}", "Bob", "192.168.1.1");
-
-            await _testKit.AwaitConditionAsync(() => 
-                AssertCondition(logEvent =>
-                {
-                    logEvent.Properties.Should().ContainKey("0");
-                    logEvent.Properties.Should().ContainKey("1");
-                    logEvent.Properties["0"].ToString().Should().Be("\"Bob\"");
-                    logEvent.Properties["1"].ToString().Should().Be("\"192.168.1.1\"");
-                }));
+            await _testKit.AwaitAssertAsync(() =>
+            {
+                _loggingAdapter.Info("User {0} logged in from {1}", "Bob", "192.168.1.1");
+                var logEvent = GetMatchingLogEvent(e => e.Properties.ContainsKey("0"));
+                logEvent.Should().NotBeNull();
+                logEvent!.Properties["0"].ToString().Should().Be("\"Bob\"");
+                logEvent.Properties["1"].ToString().Should().Be("\"192.168.1.1\"");
+            });
         }
 
         [Fact(DisplayName = "Should handle multiple named properties in template")]
         public async Task MultipleNamedPropertiesTest()
         {
             _sink.Clear();
-            await _testKit.AwaitConditionAsync(() => _sink.Writes.Count == 0);
 
-            _loggingAdapter.Info("Order {OrderId} for customer {CustomerId}: {Amount} {Currency}",
-                "ORD-001", "CUST-456", 99.99, "USD");
-
-            await _testKit.AwaitConditionAsync(() => 
-                AssertCondition(logEvent =>
-                {
-                    logEvent.Properties.Should().ContainKeys("OrderId", "CustomerId", "Amount", "Currency");
-                    logEvent.Properties["OrderId"].ToString().Should().Be("\"ORD-001\"");
-                    logEvent.Properties["CustomerId"].ToString().Should().Be("\"CUST-456\"");
-                    logEvent.Properties["Amount"].ToString().Should().Be("99.99");
-                    logEvent.Properties["Currency"].ToString().Should().Be("\"USD\"");
-                }));
+            await _testKit.AwaitAssertAsync(() =>
+            {
+                _loggingAdapter.Info("Order {OrderId} for customer {CustomerId}: {Amount} {Currency}",
+                    "ORD-001", "CUST-456", 99.99, "USD");
+                var logEvent = GetMatchingLogEvent(e => e.Properties.ContainsKey("OrderId"));
+                logEvent.Should().NotBeNull();
+                logEvent!.Properties["OrderId"].ToString().Should().Be("\"ORD-001\"");
+                logEvent.Properties["CustomerId"].ToString().Should().Be("\"CUST-456\"");
+                logEvent.Properties["Amount"].ToString().Should().Be("99.99");
+                logEvent.Properties["Currency"].ToString().Should().Be("\"USD\"");
+            });
         }
 
         [Fact(DisplayName = "Should preserve Akka metadata properties alongside semantic logging properties")]
         public async Task AkkaMetadataAndSemanticPropertiesTest()
         {
             _sink.Clear();
-            await _testKit.AwaitConditionAsync(() => _sink.Writes.Count == 0);
 
-            _loggingAdapter.Info("User {UserId} action", 999);
+            await _testKit.AwaitAssertAsync(() =>
+            {
+                _loggingAdapter.Info("User {UserId} action", 999);
+                var logEvent = GetMatchingLogEvent(e => e.Properties.ContainsKey("UserId"));
+                logEvent.Should().NotBeNull();
 
-            await _testKit.AwaitConditionAsync(() => 
-                AssertCondition(logEvent =>
-                {
-                    // Semantic property
-                    logEvent.Properties.Should().ContainKey("UserId");
-                    logEvent.Properties["UserId"].ToString().Should().Be("999");
+                // Semantic property
+                logEvent!.Properties["UserId"].ToString().Should().Be("999");
 
-                    // Akka metadata properties
-                    logEvent.Properties.Should().ContainKey("ActorPath");
-                    logEvent.Properties.Should().ContainKey("LogSource");
-                    logEvent.Properties.Should().ContainKey("Thread");
-                }));
+                // Akka metadata properties
+                logEvent.Properties.Should().ContainKey("ActorPath");
+                logEvent.Properties.Should().ContainKey("LogSource");
+                logEvent.Properties.Should().ContainKey("Thread");
+            });
         }
 
         [Fact(DisplayName = "Should handle Serilog destructuring operator")]
         public async Task DestructuringOperatorTest()
         {
             _sink.Clear();
-            await _testKit.AwaitConditionAsync(() => _sink.Writes.Count == 0);
 
             var user = new { Name = "Alice", Age = 30, Role = "Admin" };
-            _loggingAdapter.Info("Processing user {@User}", user);
+            await _testKit.AwaitAssertAsync(() =>
+            {
+                _loggingAdapter.Info("Processing user {@User}", user);
+                var logEvent = GetMatchingLogEvent(e => e.Properties.ContainsKey("User"));
+                logEvent.Should().NotBeNull();
 
-            await _testKit.AwaitConditionAsync(() => 
-                AssertCondition(logEvent =>
-                {
-                    // Property name is "User" (@ operator removed by Akka's parser)
-                    logEvent.Properties.Should().ContainKey("User");
+                // Serilog should have destructured the object
+                var userProperty = logEvent!.Properties["User"];
+                userProperty.Should().BeOfType<StructureValue>();
 
-                    // Serilog should have destructured the object
-                    var userProperty = logEvent.Properties["User"];
-                    userProperty.Should().BeOfType<StructureValue>();
-
-                    var structure = (StructureValue)userProperty;
-                    structure.Properties.Should().Contain(p => p.Name == "Name");
-                    structure.Properties.Should().Contain(p => p.Name == "Age");
-                    structure.Properties.Should().Contain(p => p.Name == "Role");
-                }));
+                var structure = (StructureValue)userProperty;
+                structure.Properties.Should().Contain(p => p.Name == "Name");
+                structure.Properties.Should().Contain(p => p.Name == "Age");
+                structure.Properties.Should().Contain(p => p.Name == "Role");
+            });
         }
 
         [Fact(DisplayName = "Should handle Serilog stringification operator")]
         public async Task StringificationOperatorTest()
         {
             _sink.Clear();
-            await _testKit.AwaitConditionAsync(() => _sink.Writes.Count == 0);
 
             var exception = new InvalidOperationException("Test error");
-            _loggingAdapter.Info("Error occurred: {$Exception}", exception);
+            await _testKit.AwaitAssertAsync(() =>
+            {
+                _loggingAdapter.Info("Error occurred: {$Exception}", exception);
+                var logEvent = GetMatchingLogEvent(e => e.Properties.ContainsKey("Exception"));
+                logEvent.Should().NotBeNull();
 
-            await _testKit.AwaitConditionAsync(() => 
-                AssertCondition(logEvent =>
-                {
-                    // Property name is "Exception" ($ operator removed by Akka's parser)
-                    logEvent.Properties.Should().ContainKey("Exception");
-
-                    // Serilog should have used ToString() instead of destructuring
-                    var exceptionProperty = logEvent.Properties["Exception"];
-                    exceptionProperty.Should().BeOfType<ScalarValue>();
-                }));
+                // Serilog should have used ToString() instead of destructuring
+                var exceptionProperty = logEvent!.Properties["Exception"];
+                exceptionProperty.Should().BeOfType<ScalarValue>();
+            });
         }
 
         [Fact(DisplayName = "Should handle format specifiers in named templates")]
         public async Task FormatSpecifiersInTemplatesTest()
         {
             _sink.Clear();
-            await _testKit.AwaitConditionAsync(() => _sink.Writes.Count == 0);
 
-            _loggingAdapter.Info("Total amount: {Amount:N2}", 1234.5678);
+            await _testKit.AwaitAssertAsync(() =>
+            {
+                _loggingAdapter.Info("Total amount: {Amount:N2}", 1234.5678);
+                var logEvent = GetMatchingLogEvent(e => e.Properties.ContainsKey("Amount"));
+                logEvent.Should().NotBeNull();
 
-            await _testKit.AwaitConditionAsync(() => 
-                AssertCondition(logEvent =>
-                {
-                    // Property name is "Amount" (format specifier removed by Akka's parser)
-                    logEvent.Properties.Should().ContainKey("Amount");
-
-                    // The rendered message should apply the format
-                    logEvent.RenderMessage().Should().Contain("1,234.57");
-                }));
+                // The rendered message should apply the format
+                logEvent!.RenderMessage().Should().Contain("1,234.57");
+            });
         }
 
         [Fact(DisplayName = "Should handle empty/no properties gracefully")]
         public async Task NoPropertiesTest()
         {
             _sink.Clear();
-            await _testKit.AwaitConditionAsync(() => _sink.Writes.Count == 0);
 
-            _loggingAdapter.Info("No template properties here");
+            await _testKit.AwaitAssertAsync(() =>
+            {
+                _loggingAdapter.Info("No template properties here");
+                var logEvent = GetMatchingLogEvent(e => e.RenderMessage().Contains("No template properties here"));
+                logEvent.Should().NotBeNull();
 
-            await _testKit.AwaitConditionAsync(() => 
-                AssertCondition(logEvent =>
-                {
-                    // Should still have Akka metadata properties
-                    logEvent.Properties.Should().ContainKey("ActorPath");
-                    logEvent.Properties.Should().ContainKey("LogSource");
-                    logEvent.Properties.Should().ContainKey("Thread");
-
-                    // Message content should be preserved
-                    logEvent.RenderMessage().Should().Contain("No template properties here");
-                }));
+                // Should still have Akka metadata properties
+                logEvent!.Properties.Should().ContainKey("ActorPath");
+                logEvent.Properties.Should().ContainKey("LogSource");
+                logEvent.Properties.Should().ContainKey("Thread");
+            });
         }
 
         [Fact(DisplayName = "Should work with ForContext enrichment")]
         public async Task ForContextWithSemanticLoggingTest()
         {
             _sink.Clear();
-            await _testKit.AwaitConditionAsync(() => _sink.Writes.Count == 0);
 
             var contextLogger = _loggingAdapter.ForContext("TenantId", "TENANT-123");
-            contextLogger.Info("User {UserId} performed action", 456);
-            
-            await _testKit.AwaitConditionAsync(() => 
-                AssertCondition(logEvent =>
-                {
-                    // Should have both semantic property and context enrichment
-                    logEvent.Properties.Should().ContainKey("UserId");
-                    logEvent.Properties["UserId"].ToString().Should().Be("456");
+            await _testKit.AwaitAssertAsync(() =>
+            {
+                contextLogger.Info("User {UserId} performed action", 456);
+                var logEvent = GetMatchingLogEvent(e =>
+                    e.Properties.ContainsKey("UserId") && e.Properties.ContainsKey("TenantId"));
+                logEvent.Should().NotBeNull();
 
-                    logEvent.Properties.Should().ContainKey("TenantId");
-                    logEvent.Properties["TenantId"].ToString().Should().Be("\"TENANT-123\"");
-                }));
+                // Should have both semantic property and context enrichment
+                logEvent!.Properties["UserId"].ToString().Should().Be("456");
+                logEvent.Properties["TenantId"].ToString().Should().Be("\"TENANT-123\"");
+            });
         }
 
-        private bool AssertCondition(Action<LogEvent> assertion)
+        private LogEvent? GetMatchingLogEvent(Func<LogEvent, bool> predicate)
         {
-            while (_sink.Writes.TryDequeue(out var logEvent))
-            {
-                try
-                {
-                    assertion(logEvent);
-                    return true;
-                }
-                catch
-                {
-                    // no-op
-                }
-            }
-            return false;
+            return _sink.Writes.ToArray().FirstOrDefault(predicate);
         }
     }
 }

--- a/src/Akka.Logger.Serilog.Tests/SerilogFormattingSpecs.cs
+++ b/src/Akka.Logger.Serilog.Tests/SerilogFormattingSpecs.cs
@@ -51,29 +51,30 @@ akka.logger-formatter=""Akka.Logger.Serilog.SerilogLogMessageFormatter, Akka.Log
         public async Task RawLogOutputRegressionTest(string version, string expected, string messageFormat, object[] args)
         {
             _sink.Clear();
-            await AwaitConditionAsync(() => _sink.Writes.Count == 0);
-            
+
             _serilogLogger.Information(messageFormat, args);
 
-            await AwaitConditionAsync(() => AssertCondition(logEvent =>
+            await AwaitAssertAsync(() =>
             {
-                logEvent.RenderMessage().Should().Be(expected);
-            }));
+                _sink.Writes.ToArray().Select(e => e.RenderMessage())
+                    .Should().Contain(expected, $"output should match {version}");
+            });
         }
-        
+
         [Theory(DisplayName = "SerilogLoggingAdapter output must be compatible with previous version")]
         [MemberData(nameof(MessageFormatDataGenerator))]
         public async Task AdapterLogOutputRegressionTest(string version, string expected, string messageFormat, object[] args)
         {
             _sink.Clear();
-            await AwaitConditionAsync(() => _sink.Writes.Count == 0);
-            
-            _loggingAdapter.Info(messageFormat, args);
 
-            await AwaitConditionAsync(() => AssertCondition(logEvent =>
+            // Log inside AwaitAssertAsync so retries send fresh messages
+            // (handles race where logger isn't subscribed to EventStream yet)
+            await AwaitAssertAsync(() =>
             {
-                logEvent.RenderMessage().Should().Contain(expected);
-            }));
+                _loggingAdapter.Info(messageFormat, args);
+                _sink.Writes.ToArray().Select(e => e.RenderMessage())
+                    .Should().Contain(msg => msg.Contains(expected), $"output should match {version}");
+            });
         }
 
         [Theory(DisplayName = "Default ILoggingAdapter output must be compatible with previous version")]
@@ -81,31 +82,15 @@ akka.logger-formatter=""Akka.Logger.Serilog.SerilogLogMessageFormatter, Akka.Log
         public async Task LogOutputRegressionTest(string version, string expected, string messageFormat, object[] args)
         {
             _sink.Clear();
-            await AwaitConditionAsync(() => _sink.Writes.Count == 0);
-            
-            Sys.Log.Info(messageFormat, args);
 
-            await AwaitConditionAsync(() => AssertCondition(logEvent =>
+            // Log inside AwaitAssertAsync so retries send fresh messages
+            // (handles race where logger isn't subscribed to EventStream yet)
+            await AwaitAssertAsync(() =>
             {
-                logEvent.RenderMessage().Should().Contain(expected);
-            }));
-        }
-        
-        private bool AssertCondition(Action<LogEvent> assertion)
-        {
-            while (_sink.Writes.TryDequeue(out var logEvent))
-            {
-                try
-                {
-                    assertion(logEvent);
-                    return true;
-                }
-                catch
-                {
-                    // no-op
-                }
-            }
-            return false;
+                Sys.Log.Info(messageFormat, args);
+                _sink.Writes.ToArray().Select(e => e.RenderMessage())
+                    .Should().Contain(msg => msg.Contains(expected), $"output should match {version}");
+            });
         }
         
         [Theory]

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,14 +15,14 @@ var log = Context.GetLogger()
 log.Info("My boss makes me use {Semantic} logging", "semantic");
 ```
 And it will work without having to explicitly call `Context.GetLogger&lt;SerilogLoggingAdapter&gt;()` first.</PackageReleaseNotes>
-    <VersionPrefix>1.5.25</VersionPrefix>
+    <VersionPrefix>1.5.57</VersionPrefix>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Logger.Serilog</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaVersion>1.5.57-beta2</AkkaVersion>
+    <AkkaVersion>1.5.57</AkkaVersion>
     <AkkaHostingVersion>1.5.55.1</AkkaHostingVersion>
     <NetCoreTestVersion>net8.0</NetCoreTestVersion>
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>


### PR DESCRIPTION
## Summary
- Update Akka.NET dependency from 1.5.57-beta2 to stable 1.5.57
- Update VersionPrefix to 1.5.57
- Update release notes with current date

## Test plan
- [ ] CI passes