### PR TITLE
Bump Akka.NET to 1.5.59

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.59 January 26 2026 ####
+
+* [Update Akka.NET to 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+* [Update Akka.Hosting to 1.5.59](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)
+
 #### 1.5.58 January 9 2026 ####
 
 * [Update Akka.NET to 1.5.58](https://github.com/akkadotnet/akka.net/releases/tag/1.5.58)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,40 +3,17 @@
     <PackageTags>akka;actors;actor model;Akka;concurrency;serilog</PackageTags>
     <Copyright>Copyright © 2013-2023 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <PackageReleaseNotes>* [Update Akka.NET to 1.5.58](https://github.com/akkadotnet/akka.net/releases/tag/1.5.58)
-* [Update Akka.Hosting to 1.5.58](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.58)
-* [Add Akka.Hosting extensions for Serilog](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/283)
-* [Add LogFilter integration support](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/289)
-
-This release adds Akka.Hosting integration and LogFilter support for Serilog.
-
-**New Features:**
-
-- **Akka.Hosting Extensions**: New `AddSerilogLogging()` extension method for `LoggerConfigBuilder` that simplifies Serilog setup with Akka.Hosting. Automatically configures `SerilogLogger` and enables `SerilogLogMessageFormatter` for semantic logging.
-- **LogFilter Integration**: Serilog now properly integrates with Akka.NET's LogFilter API for source-based log filtering, enabling pre-pipeline filtering for improved performance.
-
-**Usage Example:**
-
-```csharp
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddAkka("MyActorSystem", configurationBuilder =&gt;
-{
-    configurationBuilder.WithLogging(loggerConfigBuilder =&gt;
-    {
-        loggerConfigBuilder.AddSerilogLogging();
-    });
-});
-```</PackageReleaseNotes>
-    <VersionPrefix>1.5.58</VersionPrefix>
+    <PackageReleaseNotes>* [Update Akka.NET to 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+* [Update Akka.Hosting to 1.5.59](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)</PackageReleaseNotes>
+    <VersionPrefix>1.5.59</VersionPrefix>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Logger.Serilog</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <LangVersion>12</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaVersion>1.5.58</AkkaVersion>
-    <AkkaHostingVersion>1.5.58</AkkaHostingVersion>
+    <AkkaVersion>1.5.59</AkkaVersion>
+    <AkkaHostingVersion>1.5.59</AkkaHostingVersion>
     <NetCoreTestVersion>net8.0</NetCoreTestVersion>
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>


### PR DESCRIPTION
## Summary
- Upgrade Akka.NET to 1.5.59
- Upgrade Akka.Hosting to 1.5.59

## Changes
- [Akka.NET 1.5.59 Release Notes](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
- [Akka.Hosting 1.5.59 Release Notes](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)