### PR TITLE
Fix: Use windows-2022 in release pipeline

### DIFF
--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -19,7 +19,7 @@ variables:
 jobs:
   - job: Release
     pool:
-      vmImage: windows-latest
+      vmImage: windows-2022
     steps:
       - task: UseDotNet@2
         displayName: 'Use .NET SDK from global.json'


### PR DESCRIPTION
Azure DevOps windows-latest bug workaround.