### PR TITLE
Update release date for v1.5.60

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 1.5.60 February 9 2026 ####
+#### 1.5.60 February 10 2026 ####
 
 * [Update Akka.NET to 1.5.60](https://github.com/akkadotnet/akka.net/releases/tag/1.5.60)
 * [Add WithContext() support and deprecate Serilog-specific ForContext()](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/310)


### PR DESCRIPTION
## Summary

- Update RELEASE_NOTES.md date for v1.5.60 from February 9 to February 10 (actual release date)

## Context

All substantive release changes (WithContext() support, ForContext() deprecation, version bump to 1.5.60) were already merged via #310. This PR only corrects the release date in the notes.

## Test plan

- [ ] Verify RELEASE_NOTES.md date is correct
- [ ] No code changes - documentation only