### PR TITLE
Fix incorrect WithLogging API reference in docs (should be ConfigureLoggers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ builder.Host.UseSerilog((context, config) =>
 // Register Akka.NET with Serilog logging
 builder.Services.AddAkka("MySystem", configurationBuilder =>
 {
-    configurationBuilder.WithLogging(loggerConfigBuilder =>
+    configurationBuilder.ConfigureLoggers(loggerConfigBuilder =>
     {
         loggerConfigBuilder.AddSerilogLogging();
     });

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -77,7 +77,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddAkka("MyActorSystem", configurationBuilder =>
 {
-    configurationBuilder.WithLogging(loggerConfigBuilder =>
+    configurationBuilder.ConfigureLoggers(loggerConfigBuilder =>
     {
         loggerConfigBuilder.AddSerilogLogging();
     });

--- a/src/Akka.Logger.Serilog/SerilogAkkaHostingExtensions.cs
+++ b/src/Akka.Logger.Serilog/SerilogAkkaHostingExtensions.cs
@@ -17,7 +17,7 @@ public static class SerilogAkkaHostingExtensions
     /// Adds Serilog one of the default loggers for the Akka.NET actor system and enables
     /// Serilog-style semantic logging formatting for all log messages.
     /// </summary>
-    /// <param name="configBuilder">The Akka.Hosting <see cref="LoggerConfigBuilder"/> - call <see cref="AkkaConfigurationBuilder.WithLogging"/></param>
+    /// <param name="configBuilder">The Akka.Hosting <see cref="LoggerConfigBuilder"/> - call <see cref="AkkaConfigurationBuilder.ConfigureLoggers"/></param>
     /// <param name="enableSerilogFormatter">Defaults to <c>true</c> - enables the <see cref="SerilogLogMessageFormatter"/> to be used by default.</param>
     /// <returns></returns>
     public static LoggerConfigBuilder AddSerilogLogging(this LoggerConfigBuilder configBuilder, bool enableSerilogFormatter = true)


### PR DESCRIPTION
## Summary

The Akka.Hosting setup examples in this repo reference a method `AkkaConfigurationBuilder.WithLogging(...)` that **does not exist**. The correct API is `AkkaConfigurationBuilder.ConfigureLoggers(Action<LoggerConfigBuilder>)`. Code copied from these docs **does not compile**.

This was reported by a customer who copied the README/IntelliSense sample verbatim and hit a build error. They correctly suspected `WithLogging()` "was not the correct api."

## Changes

- **`README.md`** (Quick Start / Option 1: Akka.Hosting) — `WithLogging` → `ConfigureLoggers`
- **`src/Akka.Logger.Serilog/SerilogAkkaHostingExtensions.cs`** — XML-doc `<param>` cref on `AddSerilogLogging` updated from `AkkaConfigurationBuilder.WithLogging` to `AkkaConfigurationBuilder.ConfigureLoggers`. (This is the one surfaced to users via IntelliSense.)
- **`RELEASE_NOTES.md`** — the 1.5.58 usage example, same fix. *(Historical entry — happy to drop this hunk if you'd prefer release notes stay append-only.)*

`AddSerilogLogging()` itself is correct and unchanged. The example project (`src/Examples/Akka.Hosting.LoggingDemo/Program.cs`) already uses `ConfigureLoggers` correctly and needs no change.

## Verification

`grep -rn "WithLogging" --include="*.cs" --include="*.md"` returns **zero** matches after this change. The correct API is confirmed in Akka.Hosting source (`src/Akka.Hosting/LoggingExtensions.cs`):

```csharp
public static AkkaConfigurationBuilder ConfigureLoggers(this AkkaConfigurationBuilder builder, Action<LoggerConfigBuilder> configurator)
```

No code/runtime behavior changes — documentation only.