### PR TITLE
1.5.69 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 1.5.69 June 17th 2026 ####
+
+* [Update Akka.NET to 1.5.69](https://github.com/akkadotnet/akka.net/releases/tag/1.5.69)
+* [Update Akka.Hosting to 1.5.69](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.69)
+* [Fix incorrect WithLogging API reference in docs (should be ConfigureLoggers)](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/343)
+
 #### 1.5.67 April 28th 2026 ####
 
 * [Update Akka.NET to 1.5.67](https://github.com/akkadotnet/akka.net/releases/tag/1.5.67)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,17 +3,18 @@
     <PackageTags>akka;actors;actor model;Akka;concurrency;serilog</PackageTags>
     <Copyright>Copyright © 2013-2023 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <PackageReleaseNotes>* [Update Akka.NET to 1.5.60](https://github.com/akkadotnet/akka.net/releases/tag/1.5.60)
-* [Add WithContext() support and deprecate Serilog-specific ForContext()](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/310)</PackageReleaseNotes>
-    <VersionPrefix>1.5.60</VersionPrefix>
+    <PackageReleaseNotes>* [Update Akka.NET to 1.5.69](https://github.com/akkadotnet/akka.net/releases/tag/1.5.69)
+* [Update Akka.Hosting to 1.5.69](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.69)
+* [Fix incorrect WithLogging API reference in docs (should be ConfigureLoggers)](https://github.com/akkadotnet/Akka.Logger.Serilog/pull/343)</PackageReleaseNotes>
+    <VersionPrefix>1.5.69</VersionPrefix>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Logger.Serilog</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <LangVersion>12</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <AkkaVersion>1.5.67</AkkaVersion>
-    <AkkaHostingVersion>1.5.67</AkkaHostingVersion>
+    <AkkaVersion>1.5.69</AkkaVersion>
+    <AkkaHostingVersion>1.5.69</AkkaHostingVersion>
     <NetCoreTestVersion>net8.0</NetCoreTestVersion>
     <NetFrameworkTestVersion>net48</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>


### PR DESCRIPTION
Upgrades Akka/Akka.Hosting to 1.5.69 and ships the WithLogging->ConfigureLoggers docs fix (#343). RELEASE_NOTES + Directory.Build.props version injected via the repo's build.ps1 release-notes functions. For maintainer review before tag/publish.

## Changes
- Updated `AkkaVersion` and `AkkaHostingVersion` to 1.5.69 in `src/Directory.Build.props`
- Added 1.5.69 entry to `RELEASE_NOTES.md`
- `VersionPrefix` and `PackageReleaseNotes` injected into `src/Directory.Build.props` via `Get-ReleaseNotes` / `UpdateVersionAndReleaseNotes`

## Validation
- `dotnet restore`: OK
- `dotnet build -c Release`: 0 errors, 128 pre-existing xUnit analyzer warnings
- `dotnet test --framework net8.0 -c Release`: Passed 775, Failed 0, Skipped 0